### PR TITLE
New api endpoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
     "cmake.generator": "Ninja",
     "[cpp]":{
         "editor.formatOnSave": true

--- a/galaxy.cpp
+++ b/galaxy.cpp
@@ -69,7 +69,7 @@ void Galaxy::makeGameChange(std::shared_ptr<Player> p, nlohmann::json payload)
     else
     {
         auto dot = (*current_state)((unsigned int)payload["dot"]);
-        auto change = std::make_shared<GameChange>(p, field, dot);
+        change = std::make_shared<GameChange>(p, field, dot);
     }
     change->apply(change);
     net->broadcast(players, change->toJson());

--- a/galaxy.cpp
+++ b/galaxy.cpp
@@ -61,8 +61,16 @@ void Galaxy::executeCommand(websocketpp::connection_hdl con, std::string command
 void Galaxy::makeGameChange(std::shared_ptr<Player> p, nlohmann::json payload)
 {
     auto field = (*current_state)[(unsigned int)payload["field"]];
-    auto dot = (*current_state)((unsigned int)payload["dot"]);
-    auto change = std::make_shared<GameChange>(p, field, dot);
+    std::shared_ptr<GameChange> change;
+    if (payload["dot"] == nullptr)
+    {
+        change = std::make_shared<GameChange>(p, field, nullptr);
+    }
+    else
+    {
+        auto dot = (*current_state)((unsigned int)payload["dot"]);
+        auto change = std::make_shared<GameChange>(p, field, dot);
+    }
     change->apply(change);
     net->broadcast(players, change->toJson());
     history.push_back(change);

--- a/galaxy.cpp
+++ b/galaxy.cpp
@@ -48,7 +48,8 @@ void Galaxy::executeCommand(websocketpp::connection_hdl con, std::string command
     }
     else if (command == "new_game")
     {
-        current_state->renew();
+        history.clear();
+        current_state.reset(new GameState((int)payload["width"], (int)payload["height"]));
         net->broadcast(players, toJson());
     }
     else
@@ -64,9 +65,9 @@ void Galaxy::makeGameChange(std::shared_ptr<Player> p, nlohmann::json payload)
     auto change = std::make_shared<GameChange>(p, field, dot);
     change->apply(change);
     net->broadcast(players, change->toJson());
-    history.push(change);
+    history.push_back(change);
     while (history.size() > 5)
-        history.pop();
+        history.pop_front();
 }
 
 nlohmann::json Galaxy::toJson()

--- a/galaxy.h
+++ b/galaxy.h
@@ -7,7 +7,7 @@
 #include "nlohmann/json.hpp"
 #include "gamechange.h"
 #include "gamestate.h"
-#include <queue>
+#include <list>
 
 /**
  * @todo write docs
@@ -21,7 +21,7 @@ private:
 
     std::map<websocketpp::connection_hdl, std::shared_ptr<Player>, std::owner_less<websocketpp::connection_hdl>> players;
     std::unique_ptr<GameState> current_state;
-    std::queue<std::shared_ptr<GameChange>> history;
+    std::list<std::shared_ptr<GameChange>> history;
 
     void setPlayerName(std::string name);
     void makeAMove();

--- a/gamechange.cpp
+++ b/gamechange.cpp
@@ -31,7 +31,7 @@ nlohmann::json GameChange::toJson()
     result["type"] = "game_change";
     result["player"] = player->id;
     result["field"] = affected_field->id;
-    if (new_assoziation)
+    if (!new_assoziation)
     {
         result["dot"] = nullptr;
     }

--- a/gamechange.cpp
+++ b/gamechange.cpp
@@ -12,8 +12,11 @@ void GameChange::apply(std::shared_ptr<GameChange> self)
         old_assoziation = dot;
         dot->removeField(affected_field);
     }
-    affected_field->assigned_dot = new_assoziation;
-    new_assoziation->registerField(affected_field);
+    if (new_assoziation)
+    {
+        affected_field->assigned_dot = new_assoziation;
+        new_assoziation->registerField(affected_field);
+    }
     affected_field->last_change = self;
 }
 

--- a/gamechange.cpp
+++ b/gamechange.cpp
@@ -31,6 +31,13 @@ nlohmann::json GameChange::toJson()
     result["type"] = "game_change";
     result["player"] = player->id;
     result["field"] = affected_field->id;
-    result["dot"] = new_assoziation->id;
+    if (new_assoziation)
+    {
+        result["dot"] = nullptr;
+    }
+    else
+    {
+        result["dot"] = new_assoziation->id;
+    }
     return result;
 }

--- a/gamestate.cpp
+++ b/gamestate.cpp
@@ -13,17 +13,6 @@ GameState::GameState(unsigned int x_size, unsigned int y_size) : x_size{x_size},
     generateSpace();
 }
 
-void GameState::renew()
-{
-    for (unsigned int i = 0; i < fields_by_id.size(); i++)
-    {
-        fields_by_id.at(i)->assigned_dot.reset();
-    }
-    dots_by_id.clear();
-    dots.clear();
-    generateSpace();
-}
-
 json GameState::toJson()
 {
     json game_state;

--- a/gamestate.h
+++ b/gamestate.h
@@ -43,7 +43,6 @@ private:
 
 public:
     GameState(unsigned int x_size, unsigned int y_size);
-    void renew();
     json toJson();
 
     void applyGameChange(const GameChange &change);


### PR DESCRIPTION
Enables the server to de-register a dot from a field and broadcasting this change to the clients.
closes #1 .