### PR TITLE
Fixes crash when trying to apply a game change

### DIFF
--- a/include/galaxy.hpp
+++ b/include/galaxy.hpp
@@ -19,7 +19,7 @@ private:
     Network net;
 
     std::map<web_con, shared_player, std::owner_less<web_con>> players;
-    std::list<GameChange> history;
+    std::list<std::shared_ptr<GameChange>> history;
     GameState current_state;
 
     void setPlayerName(std::string name);

--- a/src/galaxy.cpp
+++ b/src/galaxy.cpp
@@ -62,14 +62,14 @@ void Galaxy::executeCommand(web_con con, std::string command, nlohmann::json pay
 void Galaxy::makeGameChange(std::shared_ptr<Player> p, nlohmann::json payload)
 {
     auto field = current_state[(unsigned int)payload["field"]];
-    GameChange change(p, field);
+    auto change = std::make_shared<GameChange>(p, field);
     if (payload["dot"] != nullptr)
     {
-        change.set_dot(current_state((unsigned int)payload["dot"]));
+        change->set_dot(current_state((unsigned int)payload["dot"]));
     }
-    change.apply();
-    net.broadcast(players, change.toJson());
-    history.push_back(std::move(change));
+    change->apply();
+    net.broadcast(players, change->toJson());
+    history.push_back(change);
     while (history.size() > 5)
         history.pop_front();
 }

--- a/test/game_change-test.cpp
+++ b/test/game_change-test.cpp
@@ -1,0 +1,15 @@
+#include "gtest/gtest.h"
+#include "gamechange.hpp"
+
+TEST(GameChange, applyChange)
+{
+    auto field = std::make_shared<Field>(0, 0);
+    std::shared_ptr<Player> player;
+    {
+        auto change = std::make_shared<GameChange>(player, field);
+        change->apply();
+
+        ASSERT_TRUE(field->last_change.lock() == change);
+    }
+    ASSERT_FALSE(field->last_change.lock());
+}


### PR DESCRIPTION
as gamechanges where now created on stack, there are no pointers that could be assigned to a field in the "apply" function. Resulting in a "bad_weak_ptr" Exception. 

Fixed by reverting to pointers for gameChanges