### PR TITLE
Add voting mechanism

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build",
             "type": "shell",
-            "command": "./build.sh"
+            "command": "./compile.sh"
         }
     ]
 }

--- a/include/galaxy.hpp
+++ b/include/galaxy.hpp
@@ -23,7 +23,7 @@ class Galaxy : public std::enable_shared_from_this<Galaxy>
 private:
     friend NewGamePoll;
     Network net;
-    NewGamePoll poll;
+    std::unique_ptr<NewGamePoll> poll;
 
     /**
      * @brief manages all active players with their websocket connection

--- a/include/galaxy.hpp
+++ b/include/galaxy.hpp
@@ -2,13 +2,14 @@
 #define GALAXY_H
 
 #include <list>
-
+#include <memory>
 #include "nlohmann/json.hpp"
 
 #include "player.hpp"
 #include "gamechange.hpp"
 #include "gamestate.hpp"
 #include "network.hpp"
+#include "newgamepoll.hpp"
 
 typedef websocketpp::connection_hdl web_con;
 typedef std::shared_ptr<Player> shared_player;
@@ -17,10 +18,12 @@ typedef std::shared_ptr<Player> shared_player;
  * @brief Main class of this project. Manages all ressources
  *
  */
-class Galaxy
+class Galaxy : public std::enable_shared_from_this<Galaxy>
 {
 private:
+    friend NewGamePoll;
     Network net;
+    NewGamePoll poll;
 
     /**
      * @brief manages all active players with their websocket connection
@@ -53,6 +56,18 @@ private:
      * @param payload The data representing the change
      */
     void makeGameChange(shared_player p, nlohmann::json payload);
+
+    /**
+     * @brief generates a new Game
+     * 
+     * @param height 
+     * @param width 
+     */
+    void newGame();
+
+    void noitifyVoteState(nlohmann::json);
+
+    unsigned int new_height, new_width;
 
 public:
     /**

--- a/include/galaxy.hpp
+++ b/include/galaxy.hpp
@@ -56,6 +56,11 @@ private:
 
 public:
     /**
+     * @brief is used to lock the class in case voting_timer expires
+     * 
+     */
+    std::mutex my_mutex;
+    /**
      * @brief gets the Player to the corresponding connection
      *
      * @param con an active websocket connection

--- a/include/newgamepoll.hpp
+++ b/include/newgamepoll.hpp
@@ -1,0 +1,56 @@
+#ifndef NEW_GAME_POLL
+#define NEW_GAME_POLL
+#include "player.hpp"
+#include <thread>
+#include <mutex>
+#include <unordered_set>
+#include <functional>
+#include "nlohmann/json.hpp"
+
+typedef std::shared_ptr<Player> shared_player;
+typedef std::unordered_set<shared_player> player_set;
+typedef std::chrono::milliseconds millis;
+
+class Galaxy;
+class NewGamePoll
+{
+
+private:
+    player_set positive_votes;
+    player_set negative_votes;
+
+    std::mutex set_mutex;
+
+    std::shared_ptr<Galaxy> g;
+
+public:
+    bool active = false;
+    int time_left = 0;
+
+    NewGamePoll(const std::shared_ptr<Galaxy> &g) : g{g} {};
+
+    void reset(const shared_player &, int);
+
+    void registerPositiveVote(const shared_player &p)
+    {
+        std::lock_guard<std::mutex> l(set_mutex);
+        if (active)
+        {
+            positive_votes.insert(p);
+            negative_votes.erase(p);
+        }
+    };
+
+    void registerNegativeVote(const shared_player &p)
+    {
+        std::lock_guard<std::mutex> l(set_mutex);
+        if (active)
+        {
+            negative_votes.insert(p);
+            positive_votes.erase(p);
+        }
+    };
+
+    nlohmann::json toJSON();
+};
+#endif

--- a/include/newgamepoll.hpp
+++ b/include/newgamepoll.hpp
@@ -9,7 +9,6 @@
 
 typedef std::shared_ptr<Player> shared_player;
 typedef std::unordered_set<shared_player> player_set;
-typedef std::chrono::milliseconds millis;
 
 class Galaxy;
 class NewGamePoll
@@ -20,36 +19,26 @@ private:
     player_set negative_votes;
 
     std::mutex set_mutex;
+    std::condition_variable cv;
 
     std::shared_ptr<Galaxy> g;
+    int amount;
 
 public:
     bool active = false;
-    int time_left = 0;
 
     NewGamePoll(const std::shared_ptr<Galaxy> &g) : g{g} {};
 
     void reset(const shared_player &, int);
 
-    void registerPositiveVote(const shared_player &p)
+    bool allVoted()
     {
-        std::lock_guard<std::mutex> l(set_mutex);
-        if (active)
-        {
-            positive_votes.insert(p);
-            negative_votes.erase(p);
-        }
+        return positive_votes.size() + negative_votes.size() >= amount;
     };
 
-    void registerNegativeVote(const shared_player &p)
-    {
-        std::lock_guard<std::mutex> l(set_mutex);
-        if (active)
-        {
-            negative_votes.insert(p);
-            positive_votes.erase(p);
-        }
-    };
+    void registerPositiveVote(const shared_player &p);
+
+    void registerNegativeVote(const shared_player &p);
 
     nlohmann::json toJSON();
 };

--- a/src/galaxy.cpp
+++ b/src/galaxy.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include "debug_functions.hpp"
 
-Galaxy::Galaxy() : net(*this), current_state(10, 10), poll(shared_from_this())
+Galaxy::Galaxy() : net(*this), current_state(10, 10)
 {
 }
 
@@ -13,6 +13,7 @@ Galaxy::~Galaxy()
 
 void Galaxy::run()
 {
+    poll.reset(new NewGamePoll(shared_from_this()));
     DBG_LOG(MEDIUM, "Galaxy startet");
     net.run(9000);
 }
@@ -52,7 +53,7 @@ void Galaxy::executeCommand(web_con con, std::string command, nlohmann::json pay
     {
         new_height = payload["height"];
         new_width = payload["width"];
-        poll.reset(p, players.size());
+        poll->reset(p, players.size());
     }
     else
     {

--- a/src/galaxy.cpp
+++ b/src/galaxy.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include "debug_functions.hpp"
 
-Galaxy::Galaxy() : net(*this), current_state(10, 10)
+Galaxy::Galaxy() : net(*this), current_state(10, 10), poll(shared_from_this())
 {
 }
 
@@ -50,14 +50,30 @@ void Galaxy::executeCommand(web_con con, std::string command, nlohmann::json pay
     }
     else if (command == "new_game")
     {
-        history.clear();
-        current_state = GameState((int)payload["width"], (int)payload["height"]);
-        net.broadcast(players, toJson());
+        new_height = payload["height"];
+        new_width = payload["width"];
+        poll.reset(p, players.size());
     }
     else
     {
         stop();
     }
+}
+
+void Galaxy::noitifyVoteState(nlohmann::json vote)
+{
+    net.broadcast(players, vote);
+}
+
+void Galaxy::newGame()
+{
+    std::lock_guard<std::mutex> lock(net.message_mutex); // stop adding new messages
+    std::lock_guard<std::mutex> lock2(my_mutex);         // wait until current processing is done
+    net.setDiscardingTime();                             // tell network which messages should get invalidated
+
+    history.clear();
+    current_state = GameState(new_width, new_height);
+    net.broadcast(players, toJson());
 }
 
 void Galaxy::makeGameChange(std::shared_ptr<Player> p, nlohmann::json payload)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,12 +7,12 @@
 #include <unistd.h>
 #include "debug_functions.hpp"
 
-Galaxy g;
+auto g = std::make_shared<Galaxy>();
 
 void my_handler(int s)
 {
     DBG_LOG(LOW, "Signal erhalten");
-    g.stop();
+    g->stop();
 }
 
 int main(int argc, char **argv)
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
     sigaction(SIGINT, &sigIntHandler, NULL);
 
     DBG_LOG(MEDIUM, "Starte Galaxie");
-    g.run();
+    g->run();
     DBG_LOG(LOW, "Programm endet");
     return 0;
 }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -26,10 +26,10 @@ void Network::processMessages()
             return;
         DBG_LOG(MEDIUM, "prozessing Message");
         message_t current = to_process.front();
-        to_process.pop();
+        to_process.pop_front();
         lock.unlock();
+        galaxy.my_mutex.lock(); // galaxy now belongs to us;
         json msg;
-
         switch (current.type)
         {
         case SUBSCRIBE:
@@ -37,15 +37,23 @@ void Network::processMessages()
             galaxy.registerNewPlayer(current.connection);
             break;
         case MESSAGE:
-            DBG_LOG(MEDIUM, "Message verarbeiten: " + current.mesage->get_payload());
             msg = json::parse(current.mesage->get_payload());
-            galaxy.executeCommand(current.connection, msg["command"], msg["payload"]);
+            if (msg["command"] == "player_register" || current.entry_time > discarding_time)
+            {
+                DBG_LOG(MEDIUM, "Message verarbeiten: " + current.mesage->get_payload());
+                galaxy.executeCommand(current.connection, msg["command"], msg["payload"]);
+            }
+            else
+            {
+                //TODO Debug Message
+            }
             break;
         case UNSUBSCRIBE:
             DBG_LOG(MEDIUM, "Player unsubscribe");
             galaxy.deletePlayer(current.connection);
             break;
         }
+        galaxy.my_mutex.unlock();
 
         // do processing
         //         galaxy->stop();
@@ -62,6 +70,13 @@ void Network::run(uint16_t port)
     process_thread.join();
 }
 
+void Network::purgePendingMessages()
+{
+    to_process.remove_if([](const message_t &msg) {
+        return msg.type == MESSAGE;
+    });
+}
+
 void Network::stop()
 {
     server.stop_listening();
@@ -72,21 +87,22 @@ void Network::stop()
 void Network::on_open(websocketpp::connection_hdl con)
 {
     std::lock_guard<std::mutex> g(message_mutex);
-    to_process.push({con, SUBSCRIBE, nullptr});
+    to_process.push_back({con, SUBSCRIBE, nullptr});
     messages_available.notify_one();
 }
 
 void Network::on_message(websocketpp::connection_hdl con, server_t::message_ptr msg)
 {
+    auto entry = std::chrono::high_resolution_clock().now();
     std::lock_guard<std::mutex> g(message_mutex);
-    to_process.push({con, MESSAGE, msg});
+    to_process.push_back({con, MESSAGE, msg, entry});
     messages_available.notify_one();
 }
 
 void Network::on_close(websocketpp::connection_hdl con)
 {
     std::lock_guard<std::mutex> g(message_mutex);
-    to_process.push({con, UNSUBSCRIBE, nullptr});
+    to_process.push_back({con, UNSUBSCRIBE, nullptr});
     messages_available.notify_one();
 }
 

--- a/src/newgamepoll.cpp
+++ b/src/newgamepoll.cpp
@@ -1,0 +1,38 @@
+#include "galaxy.hpp"
+#include "newgamepoll.hpp"
+
+void NewGamePoll::reset(const shared_player &p, int amount)
+{
+    positive_votes.insert(p);
+    active = true;
+    time_left = 10000;
+    std::thread([&]() {
+        for (int i = 0; i < 100; i++)
+        {
+            std::this_thread::sleep_for(millis(100));
+            if (positive_votes.size() + negative_votes.size() == amount)
+                break;
+            time_left -= 100;
+            g->noitifyVoteState(toJSON());
+        }
+        std::lock_guard<std::mutex> l(set_mutex);
+        active = false;
+        if (positive_votes.size() > negative_votes.size())
+        {
+            g->newGame();
+        }
+        positive_votes.clear();
+        negative_votes.clear();
+    }).detach();
+}
+
+nlohmann::json NewGamePoll::toJSON()
+{
+    std::lock_guard<std::mutex> l(set_mutex);
+    nlohmann::json result;
+    result["type"] = "poll";
+    result["positives"] = positive_votes.size();
+    result["negatives"] = negative_votes.size();
+    result["time_left"] = time_left;
+    return result;
+}


### PR DESCRIPTION
New "new game" mode on the way \o/
when requesting a new game a third thread starts that waits until
a) 10 seconds are up OR
b) all players voted
if more than 50% of partizipating players voted for a new game, big cleanup and mutex madness begins to ensure that no more messages regarding the old game are being prozessed.

For single Player this is completly transparent becaus if you request a new game in singleplayer you instantly have a 100% approval rate.

the API endpoints vor voting are still missing, as i want to investigate some smarter ways of handling commands on serverside before implementing.